### PR TITLE
address outline color now matches the rest

### DIFF
--- a/app/assets/stylesheets/components/_address_autocomplete.scss
+++ b/app/assets/stylesheets/components/_address_autocomplete.scss
@@ -5,4 +5,16 @@
   max-width: none;
   width: 100% !important;
   box-shadow: none !important;
+
+  :focus-visible {
+    border-radius: 2px;
+    outline: .25rem solid rgba($primary, .25) !important;
+  }
 }
+
+
+// $focus-ring-width:      .25rem;
+// $focus-ring-opacity:    .25;
+// $focus-ring-color:      rgba($primary, $focus-ring-opacity);
+// $focus-ring-blur:       0;
+// $focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color;


### PR DESCRIPTION
<img width="578" alt="Screenshot 2023-11-24 at 12 44 00 pm" src="https://github.com/Johnsteisel/Book-A-Bike/assets/46877492/9959d815-5768-4eea-83f1-31e184e9817c">
